### PR TITLE
[Feature] 검색 API 구현 & 전체 작품 조회 url 누락 반영

### DIFF
--- a/backend/src/main/java/com/intoonpocket/backend/domain/work/controller/WorkController.java
+++ b/backend/src/main/java/com/intoonpocket/backend/domain/work/controller/WorkController.java
@@ -1,10 +1,12 @@
 package com.intoonpocket.backend.domain.work.controller;
 
 import com.intoonpocket.backend.domain.work.dto.WorkAllResponseDto;
+import com.intoonpocket.backend.domain.work.dto.WorkSearchResponseDto;
 import com.intoonpocket.backend.domain.work.service.WorkService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -19,5 +21,10 @@ public class WorkController{
     @GetMapping
     public Page<WorkAllResponseDto> findAllWork(Pageable pageable) {
         return workService.findAllWork(pageable);
+    }
+
+    @GetMapping("/search/{keyword}")
+    public Page<WorkSearchResponseDto> searchWork(Pageable pageable, @PathVariable String keyword) {
+        return workService.searchWork(pageable, keyword);
     }
 }

--- a/backend/src/main/java/com/intoonpocket/backend/domain/work/dto/WorkAllResponseDto.java
+++ b/backend/src/main/java/com/intoonpocket/backend/domain/work/dto/WorkAllResponseDto.java
@@ -15,6 +15,7 @@ public class WorkAllResponseDto {
     private Long id;
     private String workName;
     private String authorName;
+    private String workUrl;
     private String instargramId;
     private String imageUrl;
     private Long count;

--- a/backend/src/main/java/com/intoonpocket/backend/domain/work/dto/WorkSearchDto.java
+++ b/backend/src/main/java/com/intoonpocket/backend/domain/work/dto/WorkSearchDto.java
@@ -9,7 +9,7 @@ import java.util.List;
 @AllArgsConstructor
 @RequiredArgsConstructor
 @Builder
-public class WorkSearchResponseDto {
+public class WorkSearchDto {
     private Long id;
     private String workName;
     private String url;
@@ -18,6 +18,8 @@ public class WorkSearchResponseDto {
     private String authorName;
     private String authorInstargramId;
 
-    private List<Integer> searchTypeList;
-    private List<String> subjectList;
+    private boolean searchedByWorkName;
+    private boolean searchedByHashtag;
+    private boolean searchedByAuthorName;
+    private boolean searchedByAuthorInstargramId;
 }

--- a/backend/src/main/java/com/intoonpocket/backend/domain/work/dto/WorkSearchResponseDto.java
+++ b/backend/src/main/java/com/intoonpocket/backend/domain/work/dto/WorkSearchResponseDto.java
@@ -1,0 +1,4 @@
+package com.intoonpocket.backend.domain.work.dto;
+
+public class WorkSearchResponseDto {
+}

--- a/backend/src/main/java/com/intoonpocket/backend/domain/work/service/WorkService.java
+++ b/backend/src/main/java/com/intoonpocket/backend/domain/work/service/WorkService.java
@@ -1,6 +1,7 @@
 package com.intoonpocket.backend.domain.work.service;
 
 import com.intoonpocket.backend.domain.work.dto.WorkAllResponseDto;
+import com.intoonpocket.backend.domain.work.dto.WorkSearchResponseDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -8,4 +9,5 @@ import org.springframework.stereotype.Service;
 @Service
 public interface WorkService {
     Page<WorkAllResponseDto> findAllWork(Pageable pageable);
+    Page<WorkSearchResponseDto> searchWork(Pageable pageable, String keyword);
 }

--- a/backend/src/main/java/com/intoonpocket/backend/domain/work/service/impl/WorkServiceImpl.java
+++ b/backend/src/main/java/com/intoonpocket/backend/domain/work/service/impl/WorkServiceImpl.java
@@ -2,6 +2,7 @@ package com.intoonpocket.backend.domain.work.service.impl;
 
 import com.intoonpocket.backend.domain.work.dto.WorkAllResponseDto;
 import com.intoonpocket.backend.domain.work.dto.WorkElement;
+import com.intoonpocket.backend.domain.work.dto.WorkSearchResponseDto;
 import com.intoonpocket.backend.domain.work.entity.*;
 import com.intoonpocket.backend.domain.work.service.WorkService;
 import com.querydsl.core.QueryResults;
@@ -128,4 +129,11 @@ public class WorkServiceImpl implements WorkService {
             }
         });
     }
+
+    @Override
+    public Page<WorkSearchResponseDto> searchWork(Pageable pageable, String keyword) {
+
+        return null;
+    }
+
 }

--- a/backend/src/main/java/com/intoonpocket/backend/domain/work/service/impl/WorkServiceImpl.java
+++ b/backend/src/main/java/com/intoonpocket/backend/domain/work/service/impl/WorkServiceImpl.java
@@ -2,11 +2,14 @@ package com.intoonpocket.backend.domain.work.service.impl;
 
 import com.intoonpocket.backend.domain.work.dto.WorkAllResponseDto;
 import com.intoonpocket.backend.domain.work.dto.WorkElement;
+import com.intoonpocket.backend.domain.work.dto.WorkSearchDto;
 import com.intoonpocket.backend.domain.work.dto.WorkSearchResponseDto;
 import com.intoonpocket.backend.domain.work.entity.*;
 import com.intoonpocket.backend.domain.work.service.WorkService;
 import com.querydsl.core.QueryResults;
 import com.querydsl.core.types.Projections;
+import com.querydsl.core.types.dsl.CaseBuilder;
+import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
@@ -52,9 +55,9 @@ public class WorkServiceImpl implements WorkService {
                 .select(Projections.fields(
                         WorkAllResponseDto.class,
                         w.id, w.name.stringValue().as("workName"),
+                        w.url.stringValue().as("workUrl"), w.imageUrl, w.count,
                         a.name.stringValue().as("authorName"),
-                        a.instargramId.stringValue().as("instargramId"),
-                        w.imageUrl, w.count))
+                        a.instargramId.stringValue().as("instargramId")))
                 .from(w).join(a).on(w.author.id.eq(a.id))
                 .orderBy(w.count.desc()) // 조회수 내림차순 정렬
                 .offset(pageable.getOffset())
@@ -130,10 +133,92 @@ public class WorkServiceImpl implements WorkService {
         });
     }
 
+    /*
+        작품 검색 : 작품명, 해시태그, 작가명, 작가 계정
+     */
     @Override
     public Page<WorkSearchResponseDto> searchWork(Pageable pageable, String keyword) {
+        // keyword를 포함하는 카드 조회
+        QueryResults<WorkSearchDto> workList = getWorkContainsKeyword(pageable, keyword);
 
-        return null;
+        List<WorkSearchResponseDto> workSearchResponseDtoList = new ArrayList<>();
+        for (WorkSearchDto work : workList.getResults()) {
+            // WorkSearchResponseDTO 객체 생성 및 필드 설정
+            WorkSearchResponseDto workSearchResponseDto = WorkSearchResponseDto.builder()
+                    .id(work.getId())
+                    .workName(work.getWorkName())
+                    .url(work.getUrl())
+                    .imageUrl(work.getImageUrl())
+                    .count(work.getCount())
+                    .authorName(work.getAuthorName())
+                    .authorInstargramId(work.getAuthorInstargramId())
+                    .searchTypeList(getSearchedTypeList(work)) // 카드가 검색된 조건 리스트
+                    .subjectList(getSeachedSubjectList(work))  // 작업 검색 결과에 포함될 주제 리스트
+                    .build();
+
+            workSearchResponseDtoList.add(workSearchResponseDto);
+        }
+        return new PageImpl<>(workSearchResponseDtoList, pageable, workList.getTotal());
     }
 
+    /*
+        작품명, 해시태그, 작가명, 작가 계정 중 keyword를 포함하는 카드 조회
+     */
+    private QueryResults<WorkSearchDto> getWorkContainsKeyword(Pageable pageable, String keyword) {
+        return queryFactory
+                .select(Projections.fields(
+                        WorkSearchDto.class,
+                        w.id, w.name.stringValue().as("workName"), w.url, w.imageUrl, w.count,
+                        a.name.stringValue().as("authorName"),
+                        a.instargramId.stringValue().as("authorInstargramId"),
+                        new CaseBuilder()
+                                .when(w.id.in(
+                                        JPAExpressions.select(ws.work.id)
+                                                .from(ws)
+                                                .innerJoin(s).on(ws.subject.id.eq(s.id))
+                                                .where(s.type.containsIgnoreCase(keyword))
+                                )).then(true).otherwise(false).as("searchedByHashtag"),
+                        new CaseBuilder().when(w.name.containsIgnoreCase(keyword)).then(true).otherwise(false).as("searchedByWorkName"),
+                        new CaseBuilder().when(a.name.containsIgnoreCase(keyword)).then(true).otherwise(false).as("searchedByAuthorName"),
+                        new CaseBuilder().when(a.instargramId.containsIgnoreCase(keyword)).then(true).otherwise(false).as("searchedByAuthorInstargramId")
+                ))
+                .from(w)
+                .leftJoin(a).on(w.author.id.eq(a.id))
+                .where(w.name.containsIgnoreCase(keyword)
+                        .or(w.id.in(
+                                JPAExpressions.select(ws.work.id)
+                                        .from(ws)
+                                        .innerJoin(s).on(ws.subject.id.eq(s.id))
+                                        .where(s.type.containsIgnoreCase(keyword))
+                        ))
+                        .or(a.instargramId.containsIgnoreCase(keyword))
+                        .or(a.name.containsIgnoreCase(keyword))
+                )
+                .orderBy(w.count.desc())
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .fetchResults();
+    }
+
+    /*
+        작품명, 해시태그, 작가명, 작가 계정 중 어느 속성으로 검색되었는지 체크
+     */
+    private List<Integer> getSearchedTypeList(WorkSearchDto work) {
+        // 검색된 조건 확인
+        List<Integer> searchTypeList  = new ArrayList<>();
+        if(work.isSearchedByWorkName()) searchTypeList.add(0);
+        if(work.isSearchedByHashtag()) searchTypeList.add(1);
+        if(work.isSearchedByAuthorName()) searchTypeList.add(2);
+        if(work.isSearchedByAuthorInstargramId()) searchTypeList.add(3);
+        return searchTypeList;
+    }
+
+    private List<String> getSeachedSubjectList(WorkSearchDto work) {
+        return queryFactory
+                .select(s.type)
+                .from(w).join(ws).on(w.id.eq(ws.work.id))
+                .join(s).on(s.id.eq(ws.subject.id))
+                .where(w.id.eq(work.getId()))
+                .fetch();
+    }
 }


### PR DESCRIPTION
## 구현 기능

- 작품명, 해시태그, 작가명, 작가 계정별 검색 API 구현
- 전체 작품 조회 응답에서 누락된 url 추가

## 관련 이슈

- Close #23 

## 세부 작업 내용

- [x] GET/search/{keyword} 컨트롤러 생성
- [x] keyword로 검색한 데이터를 담을 WorkSearchDto 생성
- [x] 검색된 작품 정보와 검색된 조건, 해시태그를 포함하는 WorkSearchResponseDto 생성
- [x] 작품 검색 API 구현 및 구조화

## 참고사항
- 검색 조건은 searchTypeList에 아래와 같이 매핑됩니다.
    - 작가명 : 0
    - 해시태그 : 1
    - 작가명 : 2
    - 작가 계정 : 3

## 실행 결과
- "밍미"가 포함된 조건 2(작가명)
<img width="186" alt="image" src="https://github.com/potenday-a4mango/intoonpocket/assets/93786956/bff25652-33b2-47e4-bc26-9e94109b6f89">

- "우실"이 포함된 조건 0(작품명), 조건 2(작가명)
<img width="197" alt="image" src="https://github.com/potenday-a4mango/intoonpocket/assets/93786956/143ad728-6667-4075-a9f1-57b2abec5127">