### PR TITLE
[Infra] 백엔드 로컬 및 서버 도메인 연결&https 작업

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ gradle-app.setting
 .project
 # JDT-specific (Eclipse Java Development Tools)
 .classpath
+
+# https key
+intoonpocket.p12

--- a/.idea/encodings.xml
+++ b/.idea/encodings.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="Encoding">
+    <file url="file://$PROJECT_DIR$/intoonpocket.p12" charset="UTF-16" />
+    <file url="file://$PROJECT_DIR$/intoonpocket.p12" charset="UTF-16" />
+  </component>
+</project>

--- a/backend/src/main/java/com/intoonpocket/backend/BackendApplication.java
+++ b/backend/src/main/java/com/intoonpocket/backend/BackendApplication.java
@@ -5,9 +5,7 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
 public class BackendApplication {
-
 	public static void main(String[] args) {
 		SpringApplication.run(BackendApplication.class, args);
 	}
-
 }


### PR DESCRIPTION
## 구현 작업

- 도메인 구입
- 프론트 및 백엔드 서버 도메인 연결
    - 프론트 도메인 : intoonpocket.site 또는 www.intoonpocket.site
    - 백엔드 도메인 : server.intoonpocket.site
- 백엔드 서버 SSL 인증서 발급 및 적용하여 HTTPS 설정

## 관련 이슈

- Close #35 

## 세부 작업 내용

- [x] 도메인 작업
    - 가비아에서 "intoonpocket.site" 도메인 구입
    - 가비아에서 도메인 레코드 www, server, www.server 추가
    - NCP Global DNS에 도메인 추가 및 호스트 www, server, www.server 추가
    - NCP Global DNS의 레코드 값을 가비아 네임 서버에 등록
  
- [x] 백엔드 로컬에서 SSL 인증서 발급 및 application.yml에 설정 정보 등록

- [x] 백엔드 서버에서 Let's Encrypt SSL 적용
    - Certbot 설치
    - standalone 방식으로 구동
    - 발급된 pem을 PKCS12 형식으로 변경하고, 생성된 keystore.p12를 프로젝트 resource 하위로 이동
    - application.yml에 SSL 설정 정보 등록
    - 도메인 접속 시 포트 번호 없이 접속하기 위해 서버 포트 번호를 80으로 수정
    - 서버 80포트 방화벽 열기
    - 서버 재실행
 
## 결과
- 백엔드 서버 도메인 : https://server.intoonpocket.site/api/v1/
- 프론트엔드 도메인 : intoonpocket.site:3000
- 백엔드 배포 서버 https+도메인 접속 결과
![image](https://github.com/potenday-a4mango/intoonpocket/assets/93786956/0418c48f-81bb-4039-b172-d666f247bbfa)

- 프론트엔드 로컬 도메인 접속 결과
![image](https://github.com/potenday-a4mango/intoonpocket/assets/93786956/44bc185c-2230-43e8-9e64-496541a6e03a)