### PR TITLE
[Docs/Test] Swagger OpenAPI 적용

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -43,6 +43,8 @@ dependencies {
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.0.2'
 }
 
 // Querydsl 설정부

--- a/backend/src/main/java/com/intoonpocket/backend/BackendApplication.java
+++ b/backend/src/main/java/com/intoonpocket/backend/BackendApplication.java
@@ -1,5 +1,7 @@
 package com.intoonpocket.backend;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.servers.Server;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 

--- a/backend/src/main/java/com/intoonpocket/backend/common/exception/response/ExceptionResponseDto.java
+++ b/backend/src/main/java/com/intoonpocket/backend/common/exception/response/ExceptionResponseDto.java
@@ -1,13 +1,20 @@
 package com.intoonpocket.backend.common.exception.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Builder;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Builder
 @Getter
+@Schema(description = "예외 응답 DTO")
 public class ExceptionResponseDto {
+    @Schema(description = "Http 상태")
     private final HttpStatus httpStatus;
+
+    @Schema(description = "Http 상태 코드")
     private final String code;
+
+    @Schema(description = "예외 메시지")
     private String message;
 }

--- a/backend/src/main/java/com/intoonpocket/backend/domain/work/controller/WorkController.java
+++ b/backend/src/main/java/com/intoonpocket/backend/domain/work/controller/WorkController.java
@@ -1,37 +1,80 @@
 package com.intoonpocket.backend.domain.work.controller;
 
+import com.intoonpocket.backend.common.exception.response.ExceptionResponseDto;
 import com.intoonpocket.backend.domain.work.exception.InvalidWorkIdException;
 import com.intoonpocket.backend.domain.work.dto.request.CountRequestDto;
 import com.intoonpocket.backend.domain.work.dto.response.WorkAllResponseDto;
 import com.intoonpocket.backend.domain.work.dto.response.WorkSearchResponseDto;
 import com.intoonpocket.backend.domain.work.service.WorkService;
+import com.intoonpocket.backend.swagger.CommonApiResponses;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import jakarta.validation.Valid;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/")
+@RequestMapping("/api/v1")
 public class WorkController{
     private final WorkService workService;
 
     public WorkController(WorkService workService) {
         this.workService = workService;
     }
+
+    @Operation(summary = "작품 전체 조회", description = "전제 작품의 모든 정보를 조회", tags = {"Work Controller"})
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK",
+                content = @Content(schema = @Schema(implementation = WorkAllResponseDto.class))),
+    })
+    @CommonApiResponses
     @GetMapping
-    public Page<WorkAllResponseDto> findAllWork(Pageable pageable) {
+    public Page<WorkAllResponseDto> findAllWork(
+            @Parameter(name = "page", description = "현제 페이지 번호")
+            @RequestParam(name = "page", defaultValue = "0") int page,
+            @Parameter(name = "size", description = "한 페이지에 표시될 데이터 수")
+            @RequestParam(name = "size", defaultValue = "20") int size) {
+            Pageable pageable = PageRequest.of(page, size);
         return workService.findAllWork(pageable);
     }
 
+    @Operation(summary = "작품 검색", description = "작품의 작품명, 해시태그, 작가명, 작가 계정, 카테고리에 검색어와 일치하는 문자가 있는지 조회", tags = {"Work Controller"})
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK",
+                    content = @Content(schema = @Schema(implementation = WorkSearchResponseDto.class)))
+    })
+    @CommonApiResponses
     @GetMapping("/search/{keyword}")
-    public Page<WorkSearchResponseDto> searchWork(Pageable pageable, @PathVariable String keyword) {
+    public Page<WorkSearchResponseDto> searchWork(
+            @Parameter(description = "현제 페이지 번호") @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "한 페이지에 표시될 데이터 수") @RequestParam(defaultValue = "20") int size,
+            @Parameter(description = "검색어", in = ParameterIn.PATH, example = "직장") @PathVariable String keyword) {
+        Pageable pageable = PageRequest.of(page, size);
         return workService.searchWork(pageable, keyword);
     }
 
+    @Operation(summary = "작품 조회수 1만큼 증가", description = "작품의 count를 1만큼 증가", tags = {"Work Controller"})
+    @ApiResponses({
+            @ApiResponse(responseCode = "200", description = "OK"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 작품 ID",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "잘못된 요청 ID 타입",
+                    content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class)))
+    })
+    @CommonApiResponses
     @PostMapping("/count")
-    public ResponseEntity updateWorkCount(@Valid @RequestBody CountRequestDto countRequestDto) throws InvalidWorkIdException {
+    public ResponseEntity updateWorkCount(
+            @Parameter(description = "조회수를 증가시킬 작품의 DB 테이블 아이디")
+            @Valid @RequestBody CountRequestDto countRequestDto) throws InvalidWorkIdException {
         workService.updateWorkCount(countRequestDto);
         return new ResponseEntity(HttpStatus.OK);
     }

--- a/backend/src/main/java/com/intoonpocket/backend/domain/work/dto/request/CountRequestDto.java
+++ b/backend/src/main/java/com/intoonpocket/backend/domain/work/dto/request/CountRequestDto.java
@@ -1,5 +1,6 @@
 package com.intoonpocket.backend.domain.work.dto.request;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -10,7 +11,8 @@ import org.springframework.validation.annotation.Validated;
 @Setter
 @AllArgsConstructor
 @RequiredArgsConstructor
+@Schema(description = "작품 조회수 증가 요청 DTO")
 public class CountRequestDto {
-
+    @Schema(description = "작품 아이디", example = "1")
     private Long workId;
 }

--- a/backend/src/main/java/com/intoonpocket/backend/domain/work/dto/response/WorkAllResponseDto.java
+++ b/backend/src/main/java/com/intoonpocket/backend/domain/work/dto/response/WorkAllResponseDto.java
@@ -1,5 +1,6 @@
 package com.intoonpocket.backend.domain.work.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.util.List;
@@ -8,15 +9,32 @@ import java.util.List;
 @Setter
 @AllArgsConstructor
 @RequiredArgsConstructor
+@Schema(description = "작품 전체 조회 응답 DTO")
 public class WorkAllResponseDto {
+    @Schema(description = "작품 아이디", example = "1")
     private Long id;
-    private String workName;
-    private String authorName;
-    private String workUrl;
-    private String instargramId;
-    private String imageUrl;
-    private Long count;
-    private List<String> workSubjectList;
-    private List<String> workCategoryList;
 
+    @Schema(description = "작품명", example = "테스트작품명")
+    private String workName;
+
+    @Schema(description = "작가명", example = "테스트작가명")
+    private String authorName;
+
+    @Schema(description = "작품 인스타그램 게시글 주소", example = "https://www.instagram.com/test-url")
+    private String workUrl;
+
+    @Schema(description = "작가 인스타그램 아이디", example = "test_writer")
+    private String instargramId;
+
+    @Schema(description = "작품 대표 이미지 경로", example = "https://kr.object.ncloudstoreage.com/test-object-url")
+    private String imageUrl;
+
+    @Schema(description = "작품 조회수", example = "10")
+    private Long count;
+
+    @Schema(description = "작품 주제", example = "['카페투어', '공감']")
+    private List<String> workSubjectList;
+
+    @Schema(description = "작품 카테고리", example = "['일상']")
+    private List<String> workCategoryList;
 }

--- a/backend/src/main/java/com/intoonpocket/backend/domain/work/dto/response/WorkSearchResponseDto.java
+++ b/backend/src/main/java/com/intoonpocket/backend/domain/work/dto/response/WorkSearchResponseDto.java
@@ -1,5 +1,6 @@
 package com.intoonpocket.backend.domain.work.dto.response;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.*;
 
 import java.util.List;
@@ -9,15 +10,32 @@ import java.util.List;
 @AllArgsConstructor
 @RequiredArgsConstructor
 @Builder
+@Schema(description = "작품 검색 응답 DTO")
 public class WorkSearchResponseDto {
+    @Schema(description = "작품 아이디", example = "1")
     private Long id;
+
+    @Schema(description = "작품명", example = "테스트작품명")
     private String workName;
+
+    @Schema(description = "작품 인스타그램 게시글 주소", example = "https://www.instagram.com/test-url")
     private String url;
+
+    @Schema(description = "작품 대표 이미지 경로", example = "https://kr.object.ncloudstoreage.com/test-object-url")
     private String imageUrl;
+
+    @Schema(description = "작품 조회수", example = "10")
     private Long count;
+
+    @Schema(description = "작가명", example = "테스트작가명")
     private String authorName;
+
+    @Schema(description = "작가 인스타그램 아이디", example = "test_writer")
     private String authorInstargramId;
 
+    @Schema(description = "작품 주제", example = "[1, 3]")
     private List<Integer> searchTypeList;
+
+    @Schema(description = "작품 카테고리", example = "['일상']")
     private List<String> subjectList;
 }

--- a/backend/src/main/java/com/intoonpocket/backend/swagger/CommonApiResponses.java
+++ b/backend/src/main/java/com/intoonpocket/backend/swagger/CommonApiResponses.java
@@ -1,0 +1,28 @@
+package com.intoonpocket.backend.swagger;
+
+import com.intoonpocket.backend.common.exception.response.ExceptionResponseDto;
+import com.intoonpocket.backend.domain.work.dto.response.WorkSearchResponseDto;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@ApiResponses(value = {
+        @ApiResponse(responseCode = "400", description = "잘못된 요청 변수명",
+                content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))),
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스",
+                content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))),
+        @ApiResponse(responseCode = "405", description = "지원하지 않는 HTTP 메서드 요청",
+                content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))),
+        @ApiResponse(responseCode = "500", description = "예기지 않은 오류 발생",
+                content = @Content(schema = @Schema(implementation = ExceptionResponseDto.class))),
+})
+public @interface CommonApiResponses {
+}

--- a/backend/src/main/java/com/intoonpocket/backend/swagger/SwaggerConfig.java
+++ b/backend/src/main/java/com/intoonpocket/backend/swagger/SwaggerConfig.java
@@ -1,0 +1,31 @@
+package com.intoonpocket.backend.swagger;
+
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
+import io.swagger.v3.oas.annotations.servers.Server;
+import lombok.RequiredArgsConstructor;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@OpenAPIDefinition(
+        info = @Info(title = "Intoon Pocket",
+        description = "IntoonPocket API 명세",
+        version = "v1"))
+//        servers = {@Server(url = "https://server.intoonpocket.site", description = "백엔드 서버 도메인")})
+@Configuration
+@RequiredArgsConstructor
+public class SwaggerConfig {
+    @Bean
+    public GroupedOpenApi intoonpocketOpenApi() {
+        String[] paths = {"/api/v1/**"};
+
+        return GroupedOpenApi.builder()
+                .group("IntoonPocket API v1")
+                .packagesToScan("com.intoonpocket.backend")
+                .pathsToMatch(paths)
+                .build();
+    }
+}


### PR DESCRIPTION
## 구현 기능

- WorkController의 모든 API에 Swagger 적용

## 관련 이슈

- Close #50 

## 세부 작업 내용

- [x] swagger springdoc=openapi 의존성 추가
- [x] SwaggerConfig 작성
- [x] ExceptionResponseDto, CountRequestDto, WorkAllResponseDto, WorkSearchResponseDto에 @Schema를 사용하여 상세 설명 작성
- [x] 각 컨트롤러 API에 공통으로 적용되는 @ApiResponses를 @CommonApiResponsesd 어노테이션을 통해 재사용하도록 생성
- [x] @RequestMapping을 "/api/v1/"에서 "/api/v1"으로 슬래쉬 제거
- [x] "GET /api/v1", "GET /api/v1/search/{keyword}" API에서 Pageable 객체를 swagger에 명시하기 위해 매개변수로 받아오던 Pageable 객체를 page와 size로 각각 받아오도록 수정
- [x] 각 컨트롤러 API에 swagger 적용
- [x] application.yml 파일에 아래 설정 추가
    `springdoc:
  swagger-ui:
    operationsSorter: method
    path: index.html`

## 실행 결과
- 접속 경로 : https://{도메인}/swagger-ui/index.htm
- 로컬
![image](https://github.com/potenday-a4mango/intoonpocket/assets/93786956/7b8e725c-ea16-4c79-9741-227477680505)

- 배포 서버
![image](https://github.com/potenday-a4mango/intoonpocket/assets/93786956/687f8e11-16e7-4a16-8eec-a6b6c0bb1200)
